### PR TITLE
Add rgba8 and bgra8 encoding support to point_cloud_node

### DIFF
--- a/isaac_ros_stereo_image_proc/src/point_cloud_node.cpp
+++ b/isaac_ros_stereo_image_proc/src/point_cloud_node.cpp
@@ -216,11 +216,21 @@ RGBProperties PointCloudNode::CreateRGBProperties(
     rgb_properties.green_offset = 1;
     rgb_properties.blue_offset = 2;
     rgb_properties.color_step = 3;
+  } else if (rgb_msg->encoding == sensor_msgs::image_encodings::RGBA8) {
+    rgb_properties.red_offset = 0;
+    rgb_properties.green_offset = 1;
+    rgb_properties.blue_offset = 2;
+    rgb_properties.color_step = 4;
   } else if (rgb_msg->encoding == sensor_msgs::image_encodings::BGR8) {
     rgb_properties.blue_offset = 0;
     rgb_properties.green_offset = 1;
     rgb_properties.red_offset = 2;
     rgb_properties.color_step = 3;
+  } else if (rgb_msg->encoding == sensor_msgs::image_encodings::BGRA8) {
+    rgb_properties.blue_offset = 0;
+    rgb_properties.green_offset = 1;
+    rgb_properties.red_offset = 2;
+    rgb_properties.color_step = 4;
   } else if (rgb_msg->encoding == sensor_msgs::image_encodings::MONO8) {
     rgb_properties.red_offset = 0;
     rgb_properties.green_offset = 0;

--- a/isaac_ros_stereo_image_proc/src/point_cloud_node.cpp
+++ b/isaac_ros_stereo_image_proc/src/point_cloud_node.cpp
@@ -240,6 +240,12 @@ RGBProperties PointCloudNode::CreateRGBProperties(
     throw InvalidImageFormatError(
             "Unsupported encoding " + rgb_msg->encoding + "! Not publishing color");
   }
+
+  if (rgb_msg->encoding == sensor_msgs::image_encodings::RGBA8 ||
+    rgb_msg->encoding == sensor_msgs::image_encodings::BGRA8) {
+      RCLCPP_WARN_ONCE(get_logger(), 
+        "Received encoding " + rgb_msg->encoding + " dropping alpha channel to compute color");
+  }
   return rgb_properties;
 }
 


### PR DESCRIPTION
This PR adds support for point cloud creation from RGBA8 or BGRA8 images. It extends the existing logic, skipping the information from the alpha channel and using only the information from the first 3 channels

As this could be interpreted as 'unexpected behavior' an warning message is issued stating that the alpha channel is being ignored when computing each point color

As example, here a point cloud generated from data from [CARLA simulator](https://github.com/carla-simulator/carla) with [CARLA ros-bridge](https://github.com/carla-simulator/ros-bridge), that produces bgra8 images

![Captura de tela de 2022-06-15 16-41-32](https://user-images.githubusercontent.com/1054087/173912327-8575afad-b729-4e16-9984-d960f0b4ec7a.png)